### PR TITLE
Fix a remaining typo

### DIFF
--- a/src/Control/Applicative/Cancellative.hs
+++ b/src/Control/Applicative/Cancellative.hs
@@ -103,7 +103,7 @@ instance Cancellative Proxy where
 cancel1 :: (Group a, Cancellative f) => a -> f a -> f a
 cancel1 a f = cancel (pure a) <|> f
 
--- | Annihalate a 'Traversable'\'s worth of elements in a 'Cancellative'
+-- | Annihilate a 'Traversable'\'s worth of elements in a 'Cancellative'
 -- functor.
 --
 annihilate :: (Cancellative f, Traversable t) => (a -> f a) -> t a -> f (t a)


### PR DESCRIPTION
I was just browsing around and noticed that #12 forgot to fix one of the typos in a doc comment. Hereby fixed.

I found this on the haskell-cafe mailing list; looks cool!