### PR TITLE
Add a type class to calculate orders

### DIFF
--- a/group-theory.cabal
+++ b/group-theory.cabal
@@ -56,6 +56,7 @@ library
     Data.Group.Free.Church
     Data.Group.Free.Product
     Data.Group.Multiplicative
+    Data.Group.Order
     Data.Group.Permutation
 
   build-depends:

--- a/src/Data/Group.hs
+++ b/src/Data/Group.hs
@@ -37,11 +37,6 @@ module Data.Group
   -- ** Elements
 , pattern Inverse
 , pattern IdentityElem
-  -- ** Order
-, Order(..)
-, pattern Infinitary
-, pattern Finitary
-, order
   -- ** Abelianization
 , Abelianizer(..)
 , abelianize
@@ -57,9 +52,6 @@ module Data.Group
 import Data.Bool
 import "groups" Data.Group as G
 import Data.Monoid
-import Data.Ord
-
-import Numeric.Natural
 
 import Prelude hiding (negate, exponent)
 
@@ -193,51 +185,6 @@ pattern Inverse t <- (invert -> t) where
 pattern IdentityElem :: (Eq m, Monoid m) => m
 pattern IdentityElem <- ((== mempty) -> True) where
   IdentityElem = mempty
-
--- -------------------------------------------------------------------- --
--- Group order
-
--- | The order of a group element.
---
--- The order of a group element can either be infinite,
--- as in the case of @Sum Integer@, or finite, as in the
--- case of @Sum Word8@.
---
-data Order = Infinite | Finite !Natural
-  deriving (Eq, Show)
-
--- | Unidirectional pattern synonym for the infinite order of a
--- group element.
---
-pattern Infinitary :: (Eq g, Group g) => g
-pattern Infinitary <- (order -> Infinite)
-
--- | Unidirectional pattern synonym for the finite order of a
--- group element.
---
-pattern Finitary :: (Eq g, Group g) => Natural -> g
-pattern Finitary n <- (order -> Finite n)
-
--- | Calculate the exponent of a particular element in a group.
---
--- __Warning:__ If 'order' expects a 'Data.Group.FiniteGroup', this is gauranteed
--- to terminate. However, this is not true of groups in general. This will
--- spin forever if you give it something like non-zero @Sum Integer@.
---
--- === __Examples__:
---
--- >>> order @(Sum Word8) 3
--- Finite 255
---
-order :: (Eq g, Group g) => g -> Order
-order a = go 0 a where
-  go !n g
-    -- guard against ().
-    | g == mempty, n > 0 = Finite n
-    -- guard against infinite cyclic cases
-    | g == a, n > 0 = Infinite
-    | otherwise = go (succ n) (g <> a)
-{-# inline order #-}
 
 -- -------------------------------------------------------------------- --
 -- Abelianization

--- a/src/Data/Group/Finite.hs
+++ b/src/Data/Group/Finite.hs
@@ -1,5 +1,6 @@
 {-# language CPP #-}
 {-# language FlexibleInstances #-}
+{-# language BangPatterns #-}
 {-# language Safe #-}
 -- |
 -- Module       : Data.Group.Finite
@@ -19,7 +20,7 @@ module Data.Group.Finite
 ( -- * Finite groups
   FiniteGroup
   -- ** Finite group combinators
-, safeOrder
+, finiteOrder
 , safeClassify
   -- * Finite abelian groups
 , FiniteAbelianGroup
@@ -31,6 +32,7 @@ import Data.Group
 import Data.Monoid
 import Data.Proxy
 import Data.Group.Cyclic
+import Numeric.Natural (Natural)
 
 -- $setup
 --
@@ -68,18 +70,19 @@ instance (Bounded a, Num a) => FiniteGroup (Sum a)
 -- -------------------------------------------------------------------- --
 -- Finite group combinators
 
--- | A safe version of 'order' for 'FiniteGroup's.
---
--- This is gauranteed to terminate with a @Finite@ value.
+-- | Calculate the exponent of a particular element in a finite group.
 --
 -- === __Examples__:
 --
--- >>> order @(Sum Word8) 3
--- Finite 255
+-- >>> finiteOrder @(Sum Word8) 3
+-- 256
 --
-safeOrder :: (Eq g, FiniteGroup g) => g -> Order
-safeOrder = order
-{-# inline safeOrder #-}
+finiteOrder :: (Eq g, FiniteGroup g) => g -> Natural
+finiteOrder a = go 1 a where
+  go !n g
+    | g == mempty = n
+    | otherwise   = go (succ n) (g <> a)
+{-# inline finiteOrder #-}
 
 -- | Classify elements of a finite 'CyclicGroup'.
 --

--- a/src/Data/Group/Free.hs
+++ b/src/Data/Group/Free.hs
@@ -37,7 +37,8 @@ import Data.Bifunctor
 import Data.List (foldl')
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Group
+import Data.Group hiding (order)
+import Data.Group.Order
 
 -- $setup
 --
@@ -71,6 +72,13 @@ instance Group (FreeGroup a) where
       . fmap (either Right Left)
       . reverse
       . runFreeGroup
+
+instance Eq a => GroupOrder (FreeGroup a) where
+    -- TODO: It performs simplify each time @order@ is called.
+    --   Once "auto-simplify" is implemented, this
+    --   call of simplify should be removed.
+    order g | simplify g == mempty = Finite 1
+            | otherwise           = Infinite
 
 instance Functor FreeGroup where
     fmap f (FreeGroup g) = FreeGroup $ fmap (bimap f f) g
@@ -143,6 +151,10 @@ instance (Ord a) => Monoid (FreeAbelianGroup a) where
 
 instance (Ord a) => Group (FreeAbelianGroup a) where
     invert (FreeAbelianGroup g) = FreeAbelianGroup $ fmap negate g
+
+instance (Ord a) => GroupOrder (FreeAbelianGroup a) where
+    order g | g == mempty = Finite 1
+            | otherwise   = Infinite
 
 -- NOTE: We can't implement Functor/Applicative/Monad here
 -- due to the Ord constraint. C'est La Vie!

--- a/src/Data/Group/Free.hs
+++ b/src/Data/Group/Free.hs
@@ -37,7 +37,7 @@ import Data.Bifunctor
 import Data.List (foldl')
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Group hiding (order)
+import Data.Group
 import Data.Group.Order
 
 -- $setup

--- a/src/Data/Group/Free/Product.hs
+++ b/src/Data/Group/Free/Product.hs
@@ -21,7 +21,7 @@ module Data.Group.Free.Product
 ) where
 
 import Data.Bifunctor
-import Data.Group hiding (order)
+import Data.Group
 import Data.Group.Order
 
 import Data.Sequence (Seq(..))

--- a/src/Data/Group/Order.hs
+++ b/src/Data/Group/Order.hs
@@ -178,7 +178,7 @@ deriving newtype instance GroupOrder a => GroupOrder (Const a b)
 deriving newtype instance GroupOrder a => GroupOrder (Identity a)
 -}
 instance GroupOrder a => GroupOrder (Down a) where
-    order = order . getDown
+    order (Down a) = order a
 
 instance GroupOrder a => GroupOrder (Dual a) where
     order = order . getDual

--- a/src/Data/Group/Order.hs
+++ b/src/Data/Group/Order.hs
@@ -1,8 +1,5 @@
-{-# language CPP #-}
+{-# language Safe #-}
 {-# language FlexibleInstances #-}
-{-# language GeneralizedNewtypeDeriving #-}
-{-# language DerivingStrategies #-}
-{-# language StandaloneDeriving #-}
 -- |
 -- Module       : Data.Group.Order
 -- Copyright    : (c) 2020 Emily Pillmore
@@ -138,7 +135,25 @@ instance (GroupOrder a, GroupOrder b, GroupOrder c, GroupOrder d, GroupOrder e)
         => GroupOrder (a,b,c,d,e) where
     order (a,b,c,d,e) = order ((a,b,c),(d,e))
 
+{- Safe Haskell doesn't allow GND, at least for now.
+{-# language
+  GeneralizedNewtypeDeriving,
+  StandaloneDeriving,
+  DerivingStrategies
+#-}
 deriving newtype instance GroupOrder a => GroupOrder (Down a)
 deriving newtype instance GroupOrder a => GroupOrder (Dual a)
 deriving newtype instance GroupOrder a => GroupOrder (Const a b)
 deriving newtype instance GroupOrder a => GroupOrder (Identity a)
+-}
+instance GroupOrder a => GroupOrder (Down a) where
+    order = order . getDown
+
+instance GroupOrder a => GroupOrder (Dual a) where
+    order = order . getDual
+
+instance GroupOrder a => GroupOrder (Const a b) where
+    order = order . getConst
+
+instance GroupOrder a => GroupOrder (Identity a) where
+    order = order . runIdentity

--- a/src/Data/Group/Order.hs
+++ b/src/Data/Group/Order.hs
@@ -1,0 +1,144 @@
+{-# language CPP #-}
+{-# language FlexibleInstances #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language DerivingStrategies #-}
+{-# language StandaloneDeriving #-}
+-- |
+-- Module       : Data.Group.Order
+-- Copyright    : (c) 2020 Emily Pillmore
+--                Koji Miyazato <viercc@gmail.com>
+-- License      : BSD-style
+--
+-- Maintainer   : Emily Pillmore <emilypi@cohomolo.gy>,
+--                Reed Mullanix <reedmullanix@gmail.com>
+-- Stability    : stable
+-- Portability  : non-portable
+--
+-- This module contains definitions for 'GroupOrder'.
+module Data.Group.Order(
+    GroupOrder(..),
+    Order(..),
+    orderForBits, lcmOrder,
+    FiniteGroup, safeOrder
+) where
+
+import Data.Monoid
+import Data.Proxy (Proxy)
+import Data.Functor.Const ( Const(..) )
+import Data.Functor.Identity ( Identity(..) )
+import Data.Ord (Down(..))
+import Data.Int(Int8, Int16, Int32, Int64)
+import Data.Word(Word8, Word16, Word32, Word64)
+
+import Data.Bits
+    ( Bits(bit), FiniteBits(countTrailingZeros, finiteBitSize) )
+import Numeric.Natural (Natural)
+
+import Data.Group(Group(..), Order(..))
+import Data.Group.Finite (FiniteGroup, safeOrder)
+
+-- | The typeclass of groups, equipped with the function
+--   computing the order of a specific element of a group.
+-- 
+-- The order of @x@ is the smallest positive integer @k@
+-- such that @'gtimes' k x == 'mempty'@. If there are no such
+-- integers, the order of @x@ is defined to be infinity.
+--   
+-- /Note:/ For any valid instances of 'GroupOrder',
+-- @order x == Finite 1@ holds if and only if @x == mempty@.
+-- 
+-- === __Examples__:
+-- 
+-- >>> order (3 :: Sum Word8)
+-- Finite 256
+-- >>> order (16 :: Sum Word8)
+-- Finite 16
+-- >>> order (0 :: Sum Integer)
+-- Finite 1
+-- >>> order (1 :: Sum Integer)
+-- Infinite
+class (Eq g, Group g) => GroupOrder g where
+    -- | The order of an element of a group.
+    --   
+    -- @order x@ must be @Finite k@ if the order of @x@ is
+    -- finite @k@, and must be @Infinite@ otherwise.
+    --   
+    -- For a type which is also 'Data.Group.Finite.FiniteGroup',
+    -- 'safeOrder' is a valid implementation of 'order',
+    -- if not efficient.
+    order :: g -> Order
+
+instance GroupOrder () where
+    order _ = Finite 1
+
+instance GroupOrder (Proxy a) where
+    order _ = Finite 1
+
+instance GroupOrder (Sum Integer) where
+    order 0 = Finite 1
+    order _ = Infinite
+
+instance GroupOrder (Sum Rational) where
+    order 0 = Finite 1
+    order _ = Infinite
+
+instance GroupOrder (Sum Int) where order = orderForBits
+instance GroupOrder (Sum Int8) where order = orderForBits
+instance GroupOrder (Sum Int16) where order = orderForBits
+instance GroupOrder (Sum Int32) where order = orderForBits
+instance GroupOrder (Sum Int64) where order = orderForBits
+instance GroupOrder (Sum Word) where order = orderForBits
+instance GroupOrder (Sum Word8) where order = orderForBits
+instance GroupOrder (Sum Word16) where order = orderForBits
+instance GroupOrder (Sum Word32) where order = orderForBits
+instance GroupOrder (Sum Word64) where order = orderForBits
+
+-- | Given a number @x :: a@ represented by fixed-width binary integers,
+--   return the minimum positive integer @2^n@ such that
+--   @(fromInteger (2^n) * x :: a) == 0@.
+zeroFactor :: FiniteBits a => a -> Natural
+zeroFactor a = bit (finiteBitSize a - countTrailingZeros a)
+
+-- | An efficient implementation of 'order' for additive group of
+--   fixed-width integers, like 'Int' or 'Word8'.
+orderForBits :: (Integral a, FiniteBits a) => Sum a -> Order
+orderForBits (Sum a) = Finite (zeroFactor a)
+
+instance GroupOrder (Product Rational) where
+    order 1 = Finite 1
+    order _ = Infinite
+
+-- | @lcmOrder x y@ calculates the least common multiple of two 'Order's.
+--   
+--   If both @x@ and @y@ are finite, it returns @'Finite' r@ where @r@
+--   is the least common multiple of them. Otherwise, it returns 'Infinite'.
+--
+-- === __Examples__:
+-- 
+-- >>> lcmOrder (Finite 2) (Finite 5)
+-- Finite 10
+-- >>> lcmOrder (Finite 2) (Finite 10)
+-- Finite 10
+-- >>> lcmOrder (Finite 1) Infinite
+-- Infinite
+lcmOrder :: Order -> Order -> Order
+lcmOrder (Finite m) (Finite n) = Finite (lcm m n)
+lcmOrder _          _          = Infinite
+
+instance (GroupOrder a, GroupOrder b) => GroupOrder (a,b) where
+    order (a,b) = order a `lcmOrder` order b
+
+instance (GroupOrder a, GroupOrder b, GroupOrder c) => GroupOrder (a,b,c) where
+    order (a,b,c) = order ((a,b),c)
+
+instance (GroupOrder a, GroupOrder b, GroupOrder c, GroupOrder d)
+        => GroupOrder (a,b,c,d) where
+    order (a,b,c,d) = order ((a,b),(c,d))
+instance (GroupOrder a, GroupOrder b, GroupOrder c, GroupOrder d, GroupOrder e)
+        => GroupOrder (a,b,c,d,e) where
+    order (a,b,c,d,e) = order ((a,b,c),(d,e))
+
+deriving newtype instance GroupOrder a => GroupOrder (Down a)
+deriving newtype instance GroupOrder a => GroupOrder (Dual a)
+deriving newtype instance GroupOrder a => GroupOrder (Const a b)
+deriving newtype instance GroupOrder a => GroupOrder (Identity a)


### PR DESCRIPTION
This PR adds `Data.Group.Order` module as one method to fix (#15), replacing the existing `Data.Group.order` function.

The last commit e2c9f8f changes the public API of this package in backward-incompatible way.