### PR TITLE
Fix on permutation groups

### DIFF
--- a/src/Data/Group/Permutation.hs
+++ b/src/Data/Group/Permutation.hs
@@ -64,7 +64,8 @@ infixr 0 $-, -$
 -- 
 -- Permutations on a finite set @a@ (, indicated by satisfying
 -- @(Bounded a, Enum a)@ constraint,) can be tested their equality
--- and computed its 'order'.
+-- and computed their 'order's.
+-- 
 -- >>> c1 = permute not not :: Permutation Bool
 -- >>> c1 <> c1 == mempty
 -- True

--- a/src/Data/Group/Permutation.hs
+++ b/src/Data/Group/Permutation.hs
@@ -90,14 +90,17 @@ instance Monoid (Permutation a) where
 instance Group (Permutation a) where
   invert (Permutation t f) = Permutation f t
 
-instance (Enum a, Bounded a) => Eq (Permutation a) where
-  (==) = (==) `on` (functionRepr . to)
+equalPermutation
+  :: (Enum a, Bounded a) => Permutation a -> Permutation a -> Bool
+equalPermutation = (==) `on` (functionRepr . to)
 
-instance (Enum a, Bounded a) => Ord (Permutation a) where
-  compare = compare `on` (functionRepr . to)
+comparePermutation
+  :: (Enum a, Bounded a) => Permutation a -> Permutation a -> Ordering
+comparePermutation = compare `on` (functionRepr . to)
 
-instance (Enum a, Bounded a) => GroupOrder (Permutation a) where
-  order Permutation{to = f} = Finite (go 1 fullSet)
+orderOfPermutation
+  :: (Enum a, Bounded a) => Permutation -> Natural
+orderOfPermutation Permutation{to = f} = go 1 fullSet
     where
       n = 1 + fromEnum (maxBound @a)
       fullSet = ISet.fromDistinctAscList [0 .. n - 1]


### PR DESCRIPTION
Noticed `Permutation` module had some off implementations, and this PR is a fix I propose.

This is an afterthought, but you might not want the added `(Enum a, Bounded a) => Eq (Permutation a)` instance,
since `a` can be finite but really big type like `Int`, making codes using `==` typecheck but practically unable to use.
